### PR TITLE
Fix numpy implementation compatibility

### DIFF
--- a/ndsplines/__init__.py
+++ b/ndsplines/__init__.py
@@ -1,3 +1,29 @@
+# get the main module so we can set impl
+from . import ndsplines
+
+# put everything from ndsplines module into package namespace
 from .ndsplines import *
 
-__all__ = [n for n in dir() if not n.startswith('_')]
+
+def set_impl(name):
+    """Set bspl implementation to either cython or numpy."""
+    global ndsplines
+    if name == 'cython':
+        try:
+            from . import _bspl
+            ndsplines.impl = _bspl
+        except ImportError:
+            raise ImportError("Can't use cython implementation. Install "
+                              "cython then reinstall ndsplines.")
+    elif name == 'numpy':
+        from . import _npy_bspl
+        ndsplines.impl = _npy_bspl
+
+
+try:
+    set_impl('cython')
+except ImportError:
+    set_impl('numpy')
+
+
+__all__ = [d for d in dir() if not d.startswith('_')]

--- a/ndsplines/__init__.py
+++ b/ndsplines/__init__.py
@@ -3,8 +3,8 @@ from .ndsplines import *
 evaluate_spline = None
 
 def set_impl(name):
-    global evaluate_spline
     """Set bspl implementation to either cython or numpy."""
+    global evaluate_spline
     if name == 'cython':
         try:
             from . import _bspl

--- a/ndsplines/__init__.py
+++ b/ndsplines/__init__.py
@@ -7,7 +7,6 @@ from .ndsplines import *
 
 def set_impl(name):
     """Set bspl implementation to either cython or numpy."""
-    global ndsplines
     if name == 'cython':
         try:
             from . import _bspl

--- a/ndsplines/__init__.py
+++ b/ndsplines/__init__.py
@@ -1,22 +1,22 @@
-# get the main module so we can set impl
-from . import ndsplines
-
-# put everything from ndsplines module into package namespace
 from .ndsplines import *
 
+evaluate_spline = None
 
 def set_impl(name):
+    global evaluate_spline
     """Set bspl implementation to either cython or numpy."""
     if name == 'cython':
         try:
             from . import _bspl
-            ndsplines.impl = _bspl
+            ndsplines.BSplineNDInterpolator.impl = _bspl
+            evaluate_spline = _bspl.evaluate_spline
         except ImportError:
             raise ImportError("Can't use cython implementation. Install "
                               "cython then reinstall ndsplines.")
     elif name == 'numpy':
         from . import _npy_bspl
-        ndsplines.impl = _npy_bspl
+        ndsplines.BSplineNDInterpolator.impl = _npy_bspl
+        evaluate_spline = _npy_bspl.evaluate_spline
 
 
 try:

--- a/ndsplines/_npy_bspl.py
+++ b/ndsplines/_npy_bspl.py
@@ -18,7 +18,7 @@ def find_intervals(t, k, x, extrapolate=False, workspace=None):
 
     Returns
     -------
-    ell : ndarray, shape=(s,) dtype=np.int_
+    ell : ndarray, shape=(s,) dtype=np.intc
         Suitable interval or -1 for each value in x
 
     Notes
@@ -32,16 +32,16 @@ def find_intervals(t, k, x, extrapolate=False, workspace=None):
 
     do_return = False
     if (not isinstance(workspace, np.ndarray) or 
-            (workspace.dtype != np.int_) or
+            (workspace.dtype != np.intc) or
             (workspace.shape[0] < t.shape[0]) or
             (workspace.shape[1] < s)):
-        workspace = np.empty((t.shape[0], s), dtype=np.int_)
+        workspace = np.empty((t.shape[0], s), dtype=np.intc)
         do_return = True
     
     ell = workspace[0,:s]
 
     # TODO: I am assuming memory is cheap and I don't get much for typing
-    # the test array as bool_ vs int_
+    # the test array as bool_ vs intc
     test = workspace[1:t.shape[0],:s]
 
     ell[:] = -1
@@ -73,7 +73,7 @@ def evaluate_spline(t, k, x, nu=0, extrapolate=False,
         order of B-spline.
     x : ndarray, shape=(s,) dtype=np.float_
         values to find the interval for
-    ell : ndarray, shape=(s,) dtype=np.int_
+    ell : ndarray, shape=(s,) dtype=np.intc
         index such that t[ell] <= x < t[ell+1] for each x
     nu : int
         order of derivative to evaluate.
@@ -94,7 +94,7 @@ def evaluate_spline(t, k, x, nu=0, extrapolate=False,
     s = x.size
 
     if (not isinstance(interval_workspace, np.ndarray) or 
-            (interval_workspace.dtype != np.int_) or
+            (interval_workspace.dtype != np.intc) or
             (interval_workspace.shape[0] < s)):
         raise ValueError("interval_workspace has invalid shape or dtype")
     ell = find_intervals(t, k, x, extrapolate)

--- a/ndsplines/ndsplines.py
+++ b/ndsplines/ndsplines.py
@@ -3,7 +3,7 @@ from scipy import interpolate
 from ndsplines import _npy_bspl
 
 __all__ = ['pinned', 'clamped', 'extrap', 'periodic', 'BSplineNDInterpolator',
-           'make_interp_spline', 'make_lsq_spline', 'impl']
+           'make_interp_spline', 'make_lsq_spline']
 
 
 """
@@ -28,8 +28,6 @@ periodic = -1
 
 bc_map =  {clamped: "clamped", pinned: "natural", extrap: None, periodic: None}
 
-impl = _npy_bspl
-
 
 class BSplineNDInterpolator(object):
     """
@@ -42,6 +40,9 @@ class BSplineNDInterpolator(object):
     periodic : ndarray, shape=(ndim,), dtype=np.bool_
     extrapolate : ndarray, shape=(ndim,2), dtype=np.bool_
     """
+
+    impl = _npy_bspl
+
     def __init__(self, knots, coefficients, orders, periodic=False, extrapolate=True):
         self.knots = knots
         self.coefficients = coefficients
@@ -95,7 +96,7 @@ class BSplineNDInterpolator(object):
                 extrapolate_flag = True
 
 
-            impl.evaluate_spline(t, k, x[i,:], nu, extrapolate_flag, self.interval_workspace[i], self.basis_workspace[i],)
+            self.impl.evaluate_spline(t, k, x[i,:], nu, extrapolate_flag, self.interval_workspace[i], self.basis_workspace[i],)
             np.add(
                 self.coefficient_selector_base[i][..., None],
                 self.interval_workspace[i][:num_points], 

--- a/ndsplines/ndsplines.py
+++ b/ndsplines/ndsplines.py
@@ -1,17 +1,9 @@
 import numpy as np
 from scipy import interpolate
 
-from ndsplines import _npy_bspl
-
-try:
-    from ndsplines import _bspl
-except ImportError:
-    default_implementation = _npy_bspl
-else:
-    default_implementation = _bspl
-
 __all__ = ['pinned', 'clamped', 'extrap', 'periodic', 'BSplineNDInterpolator',
-           'make_interp_spline', 'make_lsq_spline', 'default_implementation']
+           'make_interp_spline', 'make_lsq_spline', 'impl']
+
 
 """
 TODOs:
@@ -35,6 +27,8 @@ periodic = -1
 
 bc_map =  {clamped: "clamped", pinned: "natural", extrap: None, periodic: None}
 
+impl = None
+
 
 class BSplineNDInterpolator(object):
     """
@@ -43,12 +37,11 @@ class BSplineNDInterpolator(object):
     knots : list of ndarrays,
         shapes=[n_1+orders[i-1]+1, ..., n_ndim+orders[-1]+1], dtype=np.float_
     coefficients : ndarray, shape=(mdim, n_1, n_2, ..., n_ndim), dtype=np.float_
-    orders : ndarray, shape=(ndim,), dtype=np.int_
+    orders : ndarray, shape=(ndim,), dtype=np.intc
     periodic : ndarray, shape=(ndim,), dtype=np.bool_
     extrapolate : ndarray, shape=(ndim,2), dtype=np.bool_
     """
-    def __init__(self, knots, coefficients, orders, periodic=False, extrapolate=True, implementation=default_implementation):
-        self.implementation = implementation
+    def __init__(self, knots, coefficients, orders, periodic=False, extrapolate=True):
         self.knots = knots
         self.coefficients = coefficients
         self.ndim = len(knots) # dimension of knots
@@ -75,7 +68,7 @@ class BSplineNDInterpolator(object):
         Parameters
         ----------
         x : ndarray, shape=(self.ndim, s) dtype=np.float_
-        nus : int or ndarray, shape=(self.ndim,) dtype=np.int_
+        nus : int or ndarray, shape=(self.ndim,) dtype=np.intc
         """
         num_points = x.shape[-1]
 
@@ -101,7 +94,7 @@ class BSplineNDInterpolator(object):
                 extrapolate_flag = True
 
 
-            self.implementation.evaluate_spline(t, k, x[i,:], nu, extrapolate_flag, self.interval_workspace[i], self.basis_workspace[i],)
+            impl.evaluate_spline(t, k, x[i,:], nu, extrapolate_flag, self.interval_workspace[i], self.basis_workspace[i],)
             np.add(
                 self.coefficient_selector_base[i][..., None],
                 self.interval_workspace[i][:num_points], 
@@ -117,8 +110,10 @@ class BSplineNDInterpolator(object):
                 self.current_max_num_points,
                 2*np.max(self.orders)+3
             ), dtype=np.float_)
-            self.interval_workspace = np.empty((self.ndim, self.current_max_num_points, ), dtype=np.intc)
-            self.coefficient_selector = np.empty(self.coefficient_shape_base + (self.current_max_num_points,), dtype=np.int_)
+            self.interval_workspace = np.empty((self.ndim,
+                                                self.current_max_num_points, ),
+                                               dtype=np.intc)
+            self.coefficient_selector = np.empty(self.coefficient_shape_base + (self.current_max_num_points,), dtype=np.intc)
 
     def __call__(self, x, nus=0):
         """
@@ -126,7 +121,7 @@ class BSplineNDInterpolator(object):
         ----------
         x : ndarray, shape=(self.ndim, ...) dtype=np.float_
             Point(s) to evaluate spline on. Output will be (self.mdim,...)
-        nus : ndarray, broadcastable to shape=(self.ndim,) dtype=np.int_
+        nus : ndarray, broadcastable to shape=(self.ndim,) dtype=np.intc
             Order of derivative(s) for each dimension to evaluate
             
         """
@@ -163,7 +158,7 @@ def make_lsq_spline(x, y, knots, orders, w=None, check_finite=True):
         Ordinates.
     knots : iterable of array_like, shape (n_1 + orders[0] + 1,), ... (n_ndim, + orders[-1] + 1)
         Knots and data points must satisfy Schoenberg-Whitney conditions.
-    orders : ndarray, shape=(ndim,), dtype=np.int_
+    orders : ndarray, shape=(ndim,), dtype=np.intc
     w : array_like, shape (num_points,), optional
         Weights for spline fitting. Must be positive. If ``None``,
         then weights are all equal.
@@ -222,7 +217,7 @@ def make_interp_spline(x, y, bcs=0, orders=3):
     y : array_like, shape (mdim, n_1, n_2, ..., n_ndim)
         Ordinates.
     bcs : (list of) 2-tuples or None
-    orders : ndarray, shape=(ndim,), dtype=np.int_
+    orders : ndarray, shape=(ndim,), dtype=np.intc
         Degree of interpolant for each axis (or broadcastable)
     periodic : ndarray, shape=(ndim,), dtype=np.bool_
     extrapolate : ndarray, shape=(ndim,), dtype=np.bool_

--- a/ndsplines/ndsplines.py
+++ b/ndsplines/ndsplines.py
@@ -111,11 +111,8 @@ class BSplineNDInterpolator(object):
                 self.current_max_num_points,
                 2*np.max(self.orders)+3
             ), dtype=np.float_)
-            self.interval_workspace = np.empty((self.ndim,
-                                                self.current_max_num_points, ),
-                                               dtype=np.intc)
-            self.coefficient_selector = np.empty(self.coefficient_shape_base + (self.current_max_num_points,), dtype=np.intc)
-
+            self.interval_workspace = np.empty((self.ndim, self.current_max_num_points, ), dtype=np.intc)
+            self.coefficient_selector = np.empty(self.coefficient_shape_base + (self.current_max_num_points,), dtype=np.intc) 
     def __call__(self, x, nus=0):
         """
         Parameters

--- a/ndsplines/ndsplines.py
+++ b/ndsplines/ndsplines.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy import interpolate
+from ndsplines import _npy_bspl
 
 __all__ = ['pinned', 'clamped', 'extrap', 'periodic', 'BSplineNDInterpolator',
            'make_interp_spline', 'make_lsq_spline', 'impl']
@@ -27,7 +28,7 @@ periodic = -1
 
 bc_map =  {clamped: "clamped", pinned: "natural", extrap: None, periodic: None}
 
-impl = None
+impl = _npy_bspl
 
 
 class BSplineNDInterpolator(object):

--- a/tests/test_ndsplines.py
+++ b/tests/test_ndsplines.py
@@ -1,2 +1,14 @@
-def test_truth():
-    assert True
+import pytest
+import ndsplines
+import numpy as np
+
+
+@pytest.mark.parametrize('impl', ('cython', 'numpy'))
+def test_highlevel(impl):
+    ndsplines.set_impl(impl)
+
+    x = np.linspace(0, 1, 10)
+    xx = np.linspace(0, 1, 100)
+    y = np.sin(2*np.pi*5*x)
+    spl = ndsplines.make_interp_spline(x, y)
+    spl(xx)

--- a/tests/test_ndsplines.py
+++ b/tests/test_ndsplines.py
@@ -12,3 +12,13 @@ def test_highlevel(impl):
     y = np.sin(2*np.pi*5*x)
     spl = ndsplines.make_interp_spline(x, y)
     spl(xx)
+
+
+def test_evaluate_spline_different_impls():
+    ndsplines.set_impl('numpy')
+    f_numpy = ndsplines.evaluate_spline
+
+    ndsplines.set_impl('cython')
+    f_cython = ndsplines.evaluate_spline
+
+    assert f_numpy is not f_cython


### PR DESCRIPTION
This PR does a couple things:

- Changes all `int_` dtypes to `intc`. We talked a bit about this in #8, and I ran into an incompatible dtype error when running one of the examples using the numpy implementation. While it feels a bit weird to specify that dtype for pure Python code, I think it makes sense in this context of replacing a cython implementation. If there's a case that doesn't matter either way, I guess consistency is good.
- Adds a function to set the _bspl implementation to `'numpy'` or `'cython'`. Mechanism up for discussion. I iterated a few times and found this fairly clean in comparison to other ideas I tried. I also love how easy it is to test both implementations with pytest parametrization, so I added a high-level test to just run some data through both implementations.