### PR TITLE
Refactor `make_interp_spline` to use a single solve

### DIFF
--- a/examples/1d-interp.py
+++ b/examples/1d-interp.py
@@ -55,7 +55,7 @@ ndsplines_test_bcs = np.array([(NDspline_dict[item[0]], NDspline_dict[item[1]],)
 NDspline_bc_to_string = {tuple(v):k for k,v in NDspline_dict.items()}
 NDspline_bc_to_string[(0,-1)] = 'one-sided hold'
 
-for order in range(4):
+for order in range(3,4):
     for func in funcs:
         fvals = func(x)
         truef = func(xx)

--- a/examples/1d-interp.py
+++ b/examples/1d-interp.py
@@ -14,7 +14,7 @@ import itertools
 import ndsplines
 
 def gaussian(x_in):
-    z = norm.ppf(.995)
+    z = norm.ppf(.9995)
     x = z*(2*x_in-1)
     return norm.pdf(x)
 
@@ -28,44 +28,57 @@ def tanh(x_in):
 
 funcs = [gaussian, sin, tanh]
 
-x = np.linspace(0, 1, 7)
+x = np.linspace(0, 1, 9)
 xx = np.linspace(-.25, 1.25, 1024)
 k = 3
 
 
 test_bcs = np.array(list(itertools.chain(
-    itertools.product(["natural", "clamped"], repeat=2),
+    itertools.product(["natural", "clamped", ], repeat=2),
     ((None,None),),
 )))
 
-NDspline_dict = {"natural": ndsplines.pinned, "clamped": ndsplines.clamped, None: 0}
+# test_bcs = (None, (None,None,), "not-a-knot", ("not-a-knot", "not-a-knot"),)
 
-for func in funcs:
-    fvals = func(x)
-    truef = func(xx)
-    plt.figure()
+NDspline_dict = {"natural": ndsplines.pinned, "clamped": ndsplines.clamped, None: ndsplines.notaknot}
 
-    plot_sel = slice(None)
-
-    plt.gca().set_prop_cycle(None)
-
-    for test_bc in test_bcs[plot_sel,:]:
-        test_Bspline = interpolate.make_interp_spline(x, fvals, bc_type=list(test_bc))
+for order in range(4):
+    for func in funcs:
+        fvals = func(x)
+        truef = func(xx)
+        plt.figure()
+    
+        plot_sel = slice(None)
+    
+        plt.gca().set_prop_cycle(None)
+    
+        for test_bc in test_bcs[plot_sel,:]:
+            try:
+                test_Bspline = interpolate.make_interp_spline(x, fvals, bc_type=list(test_bc), k=order)
+            except ValueError:
+                continue
+            else:
+                splinef = test_Bspline(xx.copy(), extrapolate=True)
+                plt.plot(xx, splinef, '--', lw=3.0, label=str(test_bc) + ' (BSpline)')
+            # break
+    
+        plt.gca().set_prop_cycle(None)
+    
+        for test_bc in test_bcs[plot_sel,:]:
+            try:
+                test_NDBspline = ndsplines.make_interp_spline(x, fvals, bcs=(NDspline_dict[test_bc[0]], NDspline_dict[test_bc[1]]), orders=order)
+            except ValueError:
+                continue
+            else:
+                NDsplienf = test_NDBspline(xx.copy())
+                plt.plot(xx, NDsplienf[0], label=str(test_bc) + ' (ndspline)' )
+            # break
+    
         
-        splinef = test_Bspline(xx.copy(), extrapolate=True)
-        plt.plot(xx, splinef,'--', lw=3.0, label=str(test_bc) + ' (BSpline)')
-
-    plt.gca().set_prop_cycle(None)
-
-    for test_bc in test_bcs[plot_sel,:]:
-        test_NDBspline = ndsplines.make_interp_spline(x, fvals, bcs=(NDspline_dict[test_bc[0]], NDspline_dict[test_bc[1]]))
-        NDsplienf = test_NDBspline(xx.copy())
-        plt.plot(xx, NDsplienf[0], label=str(test_bc) + ' (ndspline)' )
-
-    
-    plt.plot(xx, truef, 'k--', label="True " + func.__name__)
-    
-    plt.legend(loc='best')
-    plt.plot(x, fvals, 'o')
-    plt.show()
+        plt.plot(xx, truef, 'k--', label="True " + func.__name__)
+        plt.plot(x, fvals, 'ko')
+        plt.title('k=%d'%order)
+        
+        plt.legend(loc='best')
+        plt.show()
     

--- a/examples/1d-interp.py
+++ b/examples/1d-interp.py
@@ -55,9 +55,6 @@ ndsplines_test_bcs = np.array([(NDspline_dict[item[0]], NDspline_dict[item[1]],)
 NDspline_bc_to_string = {tuple(v):k for k,v in NDspline_dict.items()}
 NDspline_bc_to_string[(0,-1)] = 'one-sided hold'
 
-# test_bcs = (None, (None,None,), "not-a-knot", ("not-a-knot", "not-a-knot"),)
-
-
 for order in range(4):
     for func in funcs:
         fvals = func(x)
@@ -90,7 +87,7 @@ for order in range(4):
                 continue
             else:
                 NDsplienf = test_NDBspline(xx.copy())
-                plt.plot(xx, NDsplienf[0], label=', '.join(*tuple([NDspline_bc_to_string[tuple(bc)] for bc in test_bc])) + ' (ndspline)' )
+                plt.plot(xx, NDsplienf[0], label=', '.join([NDspline_bc_to_string[tuple(bc)] for bc in test_bc]) + ' (ndspline)' )
     
         
         plt.plot(xx, truef, 'k--', label="True " + func.__name__)

--- a/examples/1d-interp.py
+++ b/examples/1d-interp.py
@@ -33,14 +33,30 @@ xx = np.linspace(-.25, 1.25, 1024)
 k = 3
 
 
-test_bcs = np.array(list(itertools.chain(
+scipy_test_bcs = np.array(list(itertools.chain(
     itertools.product(["natural", "clamped", ], repeat=2),
     ((None,None),),
 )))
 
+k0_bcs = np.array(list(
+itertools.product([(0,0), (0,-1)], repeat=2)
+)[:-1])[[-1,0,1]]
+
+NDspline_dict = {"natural": ndsplines.pinned, "clamped": ndsplines.clamped, "not-a-knot": ndsplines.notaknot}
+
+ndsplines_test_bcs = np.array([(NDspline_dict[item[0]], NDspline_dict[item[1]],)  for item in itertools.chain(
+    itertools.product(["natural", "clamped", ], repeat=2),
+    (("not-a-knot","not-a-knot"),),
+    itertools.product(["not-a-knot"],["natural", "clamped", ]),
+    itertools.product(["natural", "clamped", ], ["not-a-knot"]),
+)])
+
+
+NDspline_bc_to_string = {tuple(v):k for k,v in NDspline_dict.items()}
+NDspline_bc_to_string[(0,-1)] = 'one-sided hold'
+
 # test_bcs = (None, (None,None,), "not-a-knot", ("not-a-knot", "not-a-knot"),)
 
-NDspline_dict = {"natural": ndsplines.pinned, "clamped": ndsplines.clamped, None: ndsplines.notaknot}
 
 for order in range(4):
     for func in funcs:
@@ -52,7 +68,7 @@ for order in range(4):
     
         plt.gca().set_prop_cycle(None)
     
-        for test_bc in test_bcs[plot_sel,:]:
+        for test_bc in scipy_test_bcs[plot_sel,:]:
             try:
                 test_Bspline = interpolate.make_interp_spline(x, fvals, bc_type=list(test_bc), k=order)
             except ValueError:
@@ -60,19 +76,21 @@ for order in range(4):
             else:
                 splinef = test_Bspline(xx.copy(), extrapolate=True)
                 plt.plot(xx, splinef, '--', lw=3.0, label=str(test_bc) + ' (BSpline)')
-            # break
-    
+
         plt.gca().set_prop_cycle(None)
-    
-        for test_bc in test_bcs[plot_sel,:]:
+        
+        if order == 0:
+            bc_iter = k0_bcs
+        else:
+            bc_iter = ndsplines_test_bcs
+        for test_bc in bc_iter[plot_sel,:]:
             try:
-                test_NDBspline = ndsplines.make_interp_spline(x, fvals, bcs=(NDspline_dict[test_bc[0]], NDspline_dict[test_bc[1]]), orders=order)
+                test_NDBspline = ndsplines.make_interp_spline(x, fvals, bcs=test_bc, orders=order)
             except ValueError:
                 continue
             else:
                 NDsplienf = test_NDBspline(xx.copy())
-                plt.plot(xx, NDsplienf[0], label=str(test_bc) + ' (ndspline)' )
-            # break
+                plt.plot(xx, NDsplienf[0], label=', '.join(*tuple([NDspline_bc_to_string[tuple(bc)] for bc in test_bc])) + ' (ndspline)' )
     
         
         plt.plot(xx, truef, 'k--', label="True " + func.__name__)

--- a/examples/2d-interp.py
+++ b/examples/2d-interp.py
@@ -41,14 +41,14 @@ def wrap2d(funcx, funcy):
 funcs = [ wrap2d(*funcs_to_wrap) for funcs_to_wrap in itertools.combinations_with_replacement(funcs, r=2)]
 funcs.append(dist)
 
-x = np.linspace(0, 1, 7)
+x = np.linspace(0, 1, 5)
 y = np.linspace(0, 1, 7)
 
 xx = np.linspace(0,1,64) 
 yy = np.linspace(0,1,64)
 
-xx = np.linspace(-.25, 1.25, 64)
-yy = np.linspace(-.25, 1.25, 64)
+# xx = np.linspace(-.25, 1.25, 64)
+# yy = np.linspace(-.25, 1.25, 64)
 k = 3
 
 
@@ -62,13 +62,15 @@ gridxxyy = np.r_['0,3', meshxx, meshyy]
 for func in funcs:
     fvals = func(meshx, meshy)
     truef = func(meshxx, meshyy)
-    test_NDBspline = ndsplines.make_interp_spline(gridxy, fvals,)
-    test_RectSpline = interpolate.RectBivariateSpline(x, y, fvals)
+    test_NDBspline = ndsplines.make_interp_spline(gridxy, fvals, orders=k)
+    test_RectSpline = interpolate.RectBivariateSpline(x, y, fvals, kx=k, ky=k)
 
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
     
-    ax.plot_wireframe(meshxx, meshyy, truef, alpha=0.25, color='C0')
-    ax.plot_wireframe(meshxx, meshyy, test_NDBspline(gridxxyy)[0], color='C1')
-    ax.plot_wireframe(meshxx, meshyy, test_RectSpline(meshxx, meshyy, grid=False), color='C2')
+    ax.plot_wireframe(meshxx, meshyy, truef, alpha=0.25, color='C0', label='True')
+    ax.plot_wireframe(meshxx, meshyy, test_NDBspline(gridxxyy)[0], color='C1', label='ND')
+    ax.plot_wireframe(meshxx, meshyy, test_RectSpline(meshxx, meshyy, grid=False), color='C2', label='Rect')
+    
+    plt.legend(loc='best')
     plt.show()

--- a/ndsplines/ndsplines.py
+++ b/ndsplines/ndsplines.py
@@ -337,7 +337,7 @@ def make_interp_spline(x, y, bcs=0, orders=3):
                 t = np.r_[x_slice[0], (x_slice[:-1] + x_slice[1:])/2., x_slice[-1]]
             elif not left_zero and right_zero:
                 t = np.r_[x_slice, x_slice[-1]]
-            elif left_zero == 0 and not right_zero:
+            elif left_zero and not right_zero:
                 t = np.r_[x_slice[0], x_slice]
             else:
                 raise ValueError("Set deriv_spec = 0, with up to one side = -1 for k=0")
@@ -377,7 +377,7 @@ def make_interp_spline(x, y, bcs=0, orders=3):
         t = _as_float_array(t, check_finite)
         
     
-        if deriv_l_ords == 0:
+        if nak_spec[i-1,0]:
             deriv_l_ords = np.array([])
             deriv_l_vals = np.array([])
             nleft = 0
@@ -386,7 +386,7 @@ def make_interp_spline(x, y, bcs=0, orders=3):
             deriv_l_vals = np.broadcast_to(bcs[i-1, 0, 1], ydim)
             nleft = 1
 
-        if deriv_r_ords == 0:
+        if nak_spec[i-1,1]:
             deriv_r_ords = np.array([])
             deriv_r_vals = np.array([])
             nright = 0
@@ -425,7 +425,7 @@ def make_interp_spline(x, y, bcs=0, orders=3):
             offset_axes_remaining_sel = (tuple(idx[i-1:] + 
                 deriv_specs[i:,0]))
             y_line_sel = ((Ellipsis,) + idx[:i-1] + 
-                (slice(deriv_specs[i-1,0],-deriv_specs[i-1,0] or None),) +
+                (slice(deriv_specs[i-1,0],-deriv_specs[i-1,1] or None),) +
                 offset_axes_remaining_sel)
             coeff_line_sel = ((Ellipsis,) + idx[:i-1] + (slice(None,None),)
                 + offset_axes_remaining_sel)

--- a/ndsplines/ndsplines.py
+++ b/ndsplines/ndsplines.py
@@ -29,9 +29,6 @@ TODOs:
 create wrapper with callback to allow for creating anti-derivative splines, etc
 (use 1D operations that can be iterated over )
 
-break out some of the knot normalization stuff (in interpolate.make_interp_spline)
-to make it easier to make lsq splines? would also be useful for making the
-make_interp_spline more efficient
 
 make sure these can be pickled (maybe store knots, coeffs, orders, etc to matfile?
 
@@ -338,7 +335,7 @@ def make_interp_spline(x, y, bcs=0, orders=3):
         # END FROM SCIPY
         #=======================================
 
-
+        knots.append(t)
 
 
         for idx in np.ndindex(*all_other_ax_shape):
@@ -446,7 +443,6 @@ def make_interp_spline(x, y, bcs=0, orders=3):
             #=======================================
 
             coefficients[coeff_line_sel] = c.T
-        knots.append(t)
     return BSplineNDInterpolator(knots, coefficients, orders, 
         np.all(bcs==periodic, axis=1),
         (bcs >= 0))

--- a/ndsplines/ndsplines.py
+++ b/ndsplines/ndsplines.py
@@ -455,7 +455,7 @@ def make_interp_spline(x, y, bcs=0, orders=3):
                     ab, rhs = map(np.asarray_chkfinite, (ab, rhs))
                 gbsv, = get_lapack_funcs(('gbsv',), (ab, rhs))
                 lu, piv, c, info = gbsv(kl, ku, ab, rhs,
-                        overwrite_ab=True, overwrite_b=True)
+                        overwrite_ab=False, overwrite_b=True)
 
                 if info > 0:
                     raise LinAlgError("Collocation matix is singular.")


### PR DESCRIPTION
I refactored `make_interp_spline` to use a single solve call per dimension (the first suggestion of #28.)

It seems like there is a difference between this and the latest commit of #27. It's pretty small and is only apparent in the extrapolation (especially in the 2d interpolation example). I'm not sure where it is coming from or if it matters.