### PR TITLE
[WIP] Starting test coverage

### DIFF
--- a/tests/test_ndsplines.py
+++ b/tests/test_ndsplines.py
@@ -1,20 +1,17 @@
 import pytest
 import ndsplines
 import numpy as np
+from numpy.testing import assert_almost_equal
+import itertools
 
+np.random.seed(0)
 
-@pytest.mark.parametrize('impl', ('cython', 'numpy'))
-def test_highlevel(impl):
-    ndsplines.set_impl(impl)
-
-    x = np.linspace(0, 1, 10)
-    xx = np.linspace(0, 1, 100)
-    y = np.sin(2*np.pi*5*x)
-    spl = ndsplines.make_interp_spline(x, y)
-    spl(xx)
-
+#
+# Integration/Miscellaneous tests
+#
 
 def test_evaluate_spline_different_impls():
+    """Check that setting the backend implementation is effective."""
     ndsplines.set_impl('numpy')
     f_numpy = ndsplines.evaluate_spline
 
@@ -22,3 +19,101 @@ def test_evaluate_spline_different_impls():
     f_cython = ndsplines.evaluate_spline
 
     assert f_numpy is not f_cython
+
+
+#
+# Scipy compatibility tests
+#
+
+def test_make_interp_scipy_compat():
+    """Basic test of compatibility with scipy.interpolate API."""
+    x = np.linspace(0, 1, 10)
+    y = np.sin(x)
+    spl = ndsplines.make_interp_spline(x, y)
+    spl(np.linspace(0, 1, 100))
+
+
+# Input/output API tests
+
+def test_make_interp_invalid_x():
+    """Bad input raises ValueError."""
+    with pytest.raises(ValueError):
+        ndsplines.make_interp_spline('str', np.arange(3))
+
+
+def test_make_interp_invalid_y():
+    """Bad input raises ValueError."""
+    with pytest.raises(ValueError):
+        ndsplines.make_interp_spline(np.arange(10), np.zeros((10, 10, 10, 10)))
+
+
+@pytest.mark.parametrize('n_vals', [[8, 16], [8, 10, 12]])
+def test_make_interp_x_vectors(n_vals):
+    """Check that a list of vectors is accepted for x.
+
+    y input in this case should have shape (n_ndim1, n_ndim2, ...) as if it
+    were sampled on the grid.
+    """
+    x = [np.linspace(0, 1, n) for n in n_vals]
+    xgrid = np.stack(np.meshgrid(*x, indexing='ij'))
+    y = np.random.rand(*n_vals)
+
+    spl = ndsplines.make_interp_spline(x, y)
+
+    assert spl.xdim == len(n_vals)
+    assert spl.ydim == 1
+    assert_almost_equal(spl(xgrid), y)
+
+
+@pytest.mark.parametrize('n_vals', [[10], [10, 12], [10, 12, 15]])
+def test_make_interp_x_mesh(n_vals):
+    """Input x arrays of varying dimensionality."""
+    xarrays = [np.linspace(0, 1, n) for n in n_vals]
+    x = np.stack(np.meshgrid(*xarrays, indexing='ij'))
+    y = np.random.rand(*n_vals)
+
+    spl = ndsplines.make_interp_spline(x, y)
+    assert spl.xdim == len(n_vals)
+
+    xsamp = np.random.randn(len(n_vals), 10)
+    assert spl(xsamp).shape == (10,)
+
+
+@pytest.mark.parametrize('ydim', [2, 3])
+def test_make_interp_nd_y(ydim):
+    """Multi-dimensional y."""
+    x = np.linspace(0, 1, 10)
+    y = np.random.rand(ydim, 10)
+
+    spl = ndsplines.make_interp_spline(x, y)
+
+    assert spl.xdim == 1
+    assert spl.ydim == ydim
+
+    samps = spl(np.random.rand(20))
+    assert samps.shape == (ydim, 20)
+
+
+def test_make_interp_1d_y():
+    """Check that output is squeezed ndim==1 for 1D y."""
+    x = np.linspace(0, 1, 10)
+    y = np.sin(x)
+    spl = ndsplines.make_interp_spline(x, y)
+    assert spl(np.random.rand(20)).shape == (20,)
+
+
+#
+# Mathematical tests
+#
+
+def test_make_interp_nn():
+    """Verify nearest neighbor special case."""
+    dx = 0.1
+    x = np.arange(0, 1, dx)
+    y = np.sin(2*np.pi*x)
+
+    spl = ndsplines.make_interp_spline(x, y, bcs=[(0, 0), (0, 0)], orders=0)
+
+    # samples at offsets less than dx/2 will be same as original values
+    xx = x[:-1] + dx/4
+    assert_almost_equal(spl(xx), spl(x[:-1]))


### PR DESCRIPTION
Not a ton done yet but I'll keep working on adding similar tests for `make_lsq_spline` and covering bcs/orders checks (the 1d-interp script actually covers that pretty well I can reuse that potentially).

I probably shouldn't have committed the cosmetic changes to `ndsplines.py`. There was one necessary change I made in `make_interp_spline` and that's kind of buried, plus this now holds up further work on the file.

I'd say if it looks good so far, we can merge this and just continue adding tests in stages of additions to `test_ndsplines.py` with possible modifications to `ndsplines.py` to minimize merge hell if you want to change things.