### PR TITLE
Build and publish platform wheels in azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,6 @@ steps:
 
 - script: |
     python setup.py build_ext --inplace
-  failOnStderr: true
   displayName: 'Build extension module'
 
 # Install editable so code coverage works

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,9 +92,15 @@ steps:
     python setup.py bdist_wheel
   displayName: 'Build platform wheel'
 
-# https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts
-- task: PublishPipelineArtifact@1
+- task: CopyFiles@2
   inputs:
-    path: '$(System.DefaultWorkingDirectory)/dist/*.whl'
-    artifact: '$(Agent.JobName) wheel'
-  displayName: 'Publish platform wheel to artifacts'
+    contents: 'dist/**'
+    targetFolder: '$(Build.ArtifactStagingDirectory)'
+    cleanTargetFolder: true
+  displayName: 'Copy wheel to staging directory'
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathToPublish: '$(Build.ArtifactStagingDirectory)/dist'
+    artifactName: '$(Agent.JobName) wheel'
+  displayName: 'Publish wheel artifact'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,15 +66,19 @@ steps:
 - script: |
     pip install --upgrade pip
     pip install -r requirements.txt
-    pip install pytest pytest-azurepipelines pytest-cov pandas
+    pip install pytest pytest-azurepipelines pytest-cov pandas wheel
     pip list
   displayName: 'Install dependencies'
+
+- script: |
+    python setup.py build_ext --inplace
+  failOnStderr: true
+  displayName: 'Build extension module'
 
 # Install editable so code coverage works
 - script: |
     pip install -e .
-  displayName: 'Build and install'
-  failOnStderr: true
+  displayName: 'Install'
 
 - script: |
     pytest -sv --cov ndsplines
@@ -84,3 +88,14 @@ steps:
     bash <(curl -s https://codecov.io/bash) -t $(CODECOV_TOKEN)
   displayName: 'Upload coverage report'
   condition: eq('Job Linux_Py37', variables['Agent.JobName'])
+
+- script: |
+    python setup.py bdist_wheel
+  displayname: 'Build platform wheel'
+
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts
+- task: PublishPipelineArtifact@1
+  inputs:
+    path: 'dist/**'
+    artifact: '$(Agent.JobName) wheel'
+  displayName: 'Publish platform wheel to artifacts'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,8 @@ trigger:
     include:
       - master
   tags:
-    include: '*'
+    include:
+      - *
 
 # Run the pipeline for PRs against master
 pr:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,8 @@
 # For now we use a single stage and single job (copied for multiple OS/Python
 # version combinations) with steps for installing dependencies, building and
 # installing the ndsplines package, running the tests, and generating a code
-# coverage report.
+# coverage report. A source distribution and wheels for each platform are also
+# built and published as artifacts.
 #
 # References:
 #   https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema
@@ -118,5 +119,5 @@ steps:
 - task: PublishBuildArtifacts@1
   inputs:
     pathToPublish: '$(Build.ArtifactStagingDirectory)/dist'
-    artifactName: '$(Agent.JobName) wheel'
+    artifactName: '$(Agent.JobName) '
   displayName: 'Publish artifacts'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,8 @@ trigger:
   branches:
     include:
       - master
-# TODO add a rule for tags/releases (e.g. `tags: include: 'v*'` for v1.0.0 type tags)
+  tags:
+    include: '*'
 
 # Run the pipeline for PRs against master
 pr:
@@ -93,20 +94,32 @@ steps:
 # with Python 3.6 so it has something to publish
 - script: |
     python setup.py sdist
-  condition: eq('Job Linux_Py36', variables['Agent.JobName'])
+  condition: |
+    and(
+      contains(variables['Build.SourceBranch'], 'tags'),
+      eq('Job Linux_Py36', variables['Agent.JobName'])
+    )
   displayName: 'Build source distribution'
 
 # Build a wheel -- for Win/Mac, we can just go for it
 - script: |
     python setup.py bdist_wheel
-  condition: not(contains(variables['Agent.JobName'], 'Linux'))
+  condition: |
+    and(
+      contains(variables['Build.SourceBranch'], 'tags'),
+      not(contains(variables['Agent.JobName'], 'Linux'))
+    )
   displayName: 'Build platform wheel'
 
 # For Linux, we need to build a "manylinux" wheel
 # https://iscinumpy.gitlab.io/post/azure-devops-python-wheels/
 - script: |
     docker run --rm -w /io -v `pwd`:/io quay.io/pypa/manylinux2010_x86_64 /io/build_wheel.sh
-  condition: eq('Job Linux_Py37', variables['Agent.JobName'])
+  condition: |
+    and(
+      contains(variables['Build.SourceBranch'], 'tags'),
+      eq('Job Linux_Py37', variables['Agent.JobName'])
+    )
   displayName: 'Build Linux platform wheels in Docker'
 
 - task: CopyFiles@2
@@ -114,10 +127,12 @@ steps:
     contents: 'dist/**'
     targetFolder: '$(Build.ArtifactStagingDirectory)'
     cleanTargetFolder: true
+  condition: contains(variables['Build.SourceBranch'], 'tags')
   displayName: 'Copy dist contents to staging directory'
 
 - task: PublishBuildArtifacts@1
   inputs:
     pathToPublish: '$(Build.ArtifactStagingDirectory)/dist'
     artifactName: '$(Agent.JobName) '
+  condition: contains(variables['Build.SourceBranch'], 'tags')
   displayName: 'Publish artifacts'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,19 +88,34 @@ steps:
   displayName: 'Upload coverage report'
   condition: eq('Job Linux_Py37', variables['Agent.JobName'])
 
+# Only need one sdist and it shouldn't matter which platform
+- script: |
+    python setup.py sdist
+  condition: eq('Job Linux_Py37', variables['Agent.JobName'])
+  displayName: 'Build source distribution'
+
+# Build a wheel -- for Win/Mac, we can just go for it
 - script: |
     python setup.py bdist_wheel
+  condition: not(contains(variables['Agent.JobName'], 'Linux'))
   displayName: 'Build platform wheel'
+
+# For Linux, we need to build a "manylinux" wheel
+# https://iscinumpy.gitlab.io/post/azure-devops-python-wheels/
+- script: |
+    docker run --rm -w /io -v `pwd`:/io quay.io/pypa/manylinux2010_x86_64 /io/build_wheel.sh
+  condition: eq('Job Linux_Py37', variables['Agent.JobName']))
+  displayName: 'Build Linux platform wheels in Docker'
 
 - task: CopyFiles@2
   inputs:
     contents: 'dist/**'
     targetFolder: '$(Build.ArtifactStagingDirectory)'
     cleanTargetFolder: true
-  displayName: 'Copy wheel to staging directory'
+  displayName: 'Copy dist contents to staging directory'
 
 - task: PublishBuildArtifacts@1
   inputs:
     pathToPublish: '$(Build.ArtifactStagingDirectory)/dist'
     artifactName: '$(Agent.JobName) wheel'
-  displayName: 'Publish wheel artifact'
+  displayName: 'Publish artifacts'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,10 +88,11 @@ steps:
   displayName: 'Upload coverage report'
   condition: eq('Job Linux_Py37', variables['Agent.JobName'])
 
-# Only need one sdist and it shouldn't matter which platform
+# Only need one sdist and it shouldn't matter which platform. We'll use Linux
+# with Python 3.6 so it has something to publish
 - script: |
     python setup.py sdist
-  condition: eq('Job Linux_Py37', variables['Agent.JobName'])
+  condition: eq('Job Linux_Py36', variables['Agent.JobName'])
   displayName: 'Build source distribution'
 
 # Build a wheel -- for Win/Mac, we can just go for it

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ steps:
 
 - script: |
     python setup.py bdist_wheel
-  displayname: 'Build platform wheel'
+  displayName: 'Build platform wheel'
 
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts
 - task: PublishPipelineArtifact@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,7 +104,7 @@ steps:
 # https://iscinumpy.gitlab.io/post/azure-devops-python-wheels/
 - script: |
     docker run --rm -w /io -v `pwd`:/io quay.io/pypa/manylinux2010_x86_64 /io/build_wheel.sh
-  condition: eq('Job Linux_Py37', variables['Agent.JobName']))
+  condition: eq('Job Linux_Py37', variables['Agent.JobName'])
   displayName: 'Build Linux platform wheels in Docker'
 
 - task: CopyFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,8 @@ trigger:
     include:
       - master
   tags:
+    include:
+      - v*
 
 # Run the pipeline for PRs against master
 pr:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ trigger:
       - master
   tags:
     include:
-      - v*
+      - '*'
 
 # Run the pipeline for PRs against master
 pr:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,6 +95,6 @@ steps:
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts
 - task: PublishPipelineArtifact@1
   inputs:
-    path: 'dist/**'
+    path: '$(System.DefaultWorkingDirectory)/dist/*.whl'
     artifact: '$(Agent.JobName) wheel'
   displayName: 'Publish platform wheel to artifacts'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,8 +17,6 @@ trigger:
     include:
       - master
   tags:
-    include:
-      - *
 
 # Run the pipeline for PRs against master
 pr:

--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Script to build manylinux2010_x86_64 wheels.
+
+# This is intended for use with the quay.io/pypa/manylinux2010_x86_64 Docker
+# image. Azure Pipelines is set up to run this in such a container with the
+# working directory mounted at /io.
+
+set -e -x
+
+pyvers=(36 37)
+platform="manylinux2010_x86_64"
+
+for pyver in ${pyvers[@]}; do
+    pybin="/opt/python/cp${pyver}-cp${pyver}m/bin"
+    $pybin/pip install -r requirements.txt
+    $pybin/python setup.py bdist_wheel
+done
+
+for whl in dist/*.whl; do
+    auditwheel repair $whl --plat $platform -w dist
+done

--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,16 @@ else:
 
 setup(
     name=name,
-    version="0.0.5",
+    version="0.0.6rc1",
     description="Multi-dimensional splines",
-    url="https://github.com/sixpearls/ndsplines",
+    url="https://github.com/kb-press/ndsplines",
     author="Benjamin Margolis",
+    classifiers=[
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+    ],
     packages=["ndsplines"],
     ext_modules=extensions,
     license='BSD',


### PR DESCRIPTION
So far this should build wheels for each OS/Python version combination so we can at least manually download them and then upload to PyPI. We'll see.

edit: checklist

- [x] build and publish wheels
- [x] build manylinux wheels
~~- [ ] only publish the manylinux2010 wheels~~
- [x] add tag trigger and condition for building dist artifacts
~~- [ ] add publish to PyPI task~~
- [ ] test (need to push a tag so outside this PR)