### PR TITLE
Delete the unused scipy import

### DIFF
--- a/ndsplines/ndsplines.py
+++ b/ndsplines/ndsplines.py
@@ -1,6 +1,5 @@
 import numpy as np
 import operator
-from scipy._lib.six import string_types
 from scipy.linalg import get_lapack_funcs, LinAlgError
 from scipy.interpolate._bsplines import (prod, _as_float_array,
                                          _bspl as _sci_bspl)


### PR DESCRIPTION
Hello. Recently scipy released the latest version 1.5.0, which no longer supports scipy._lib.six. After reviewing all the codes, I figured that the import from scipy._lib.six is not actually used. Therefore, to delete this import could make the **ndsplines package** compatible with **the newest scipy package**.