### PR TITLE
Update CI configuration and add Python 3.8

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,26 +30,31 @@ pr:
 # Omitting stages/jobs hierarchy items because there's only one of each. The
 # matrix strategy generates copies of the job spec below for different
 # combinations of OS/Python version.
+# List of available agents:
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops
 strategy:
   matrix:
-    Linux_Py36:
-      imageName: 'ubuntu-16.04'
-      python.version: '3.6'
     Windows_Py36:
       imageName: 'vs2017-win2016'
       python.version: '3.6'
     Mac_Py36:
-      imageName: 'macOS-10.13'
+      imageName: 'macOS-10.14'
       python.version: '3.6'
-    Linux_Py37:
-      imageName: 'ubuntu-16.04'
-      python.version: '3.7'
     Windows_Py37:
       imageName: 'vs2017-win2016'
       python.version: '3.7'
     Mac_Py37:
-      imageName: 'macOS-10.13'
+      imageName: 'macOS-10.14'
       python.version: '3.7'
+    Windows_Py38:
+      imageName: 'vs2017-win2016'
+      python.version: '3.8'
+    Mac_Py38:
+      imageName: 'macOS-10.14'
+      python.version: '3.8'
+    Linux_Py38:
+      imageName: 'ubuntu-latest'
+      python.version: '3.8'
 
 # Grab an agent from the pool by image name specified by the matrix above
 pool:
@@ -65,11 +70,10 @@ steps:
     addToPath: true
   displayName: 'Use Python $(python.version)'
 
-# TODO install from requirements-dev.txt?
 - script: |
     pip install --upgrade pip
-    pip install -r requirements.txt
-    pip install pytest pytest-azurepipelines pytest-cov pandas wheel
+    pip install -r requirements-dev.txt
+    pip install pytest pytest-azurepipelines pytest-cov wheel
     pip list
   displayName: 'Install dependencies'
 
@@ -89,38 +93,25 @@ steps:
 - script: |
     bash <(curl -s https://codecov.io/bash) -t $(CODECOV_TOKEN)
   displayName: 'Upload coverage report'
-  condition: eq('Job Linux_Py37', variables['Agent.JobName'])
+  condition: contains(variables['Agent.JobName'], 'Linux')
 
-# Only need one sdist and it shouldn't matter which platform. We'll use Linux
-# with Python 3.6 so it has something to publish
+# Only need one sdist and it shouldn't matter which platform
 - script: |
     python setup.py sdist
-  condition: |
-    and(
-      contains(variables['Build.SourceBranch'], 'tags'),
-      eq('Job Linux_Py36', variables['Agent.JobName'])
-    )
+  condition: contains(variables['Agent.JobName'], 'Linux')
   displayName: 'Build source distribution'
 
 # Build a wheel -- for Win/Mac, we can just go for it
 - script: |
     python setup.py bdist_wheel
-  condition: |
-    and(
-      contains(variables['Build.SourceBranch'], 'tags'),
-      not(contains(variables['Agent.JobName'], 'Linux'))
-    )
+  condition: not(contains(variables['Agent.JobName'], 'Linux'))
   displayName: 'Build platform wheel'
 
 # For Linux, we need to build a "manylinux" wheel
 # https://iscinumpy.gitlab.io/post/azure-devops-python-wheels/
 - script: |
     docker run --rm -w /io -v `pwd`:/io quay.io/pypa/manylinux2010_x86_64 /io/build_wheel.sh
-  condition: |
-    and(
-      contains(variables['Build.SourceBranch'], 'tags'),
-      eq('Job Linux_Py37', variables['Agent.JobName'])
-    )
+  condition: contains(variables['Agent.JobName'], 'Linux')
   displayName: 'Build Linux platform wheels in Docker'
 
 - task: CopyFiles@2
@@ -128,12 +119,10 @@ steps:
     contents: 'dist/**'
     targetFolder: '$(Build.ArtifactStagingDirectory)'
     cleanTargetFolder: true
-  condition: contains(variables['Build.SourceBranch'], 'tags')
   displayName: 'Copy dist contents to staging directory'
 
 - task: PublishBuildArtifacts@1
   inputs:
     pathToPublish: '$(Build.ArtifactStagingDirectory)/dist'
     artifactName: '$(Agent.JobName) '
-  condition: contains(variables['Build.SourceBranch'], 'tags')
   displayName: 'Publish artifacts'

--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -8,7 +8,7 @@
 
 set -e -x
 
-pyvers=(36 37)
+pyvers=(36 37 38)
 platform="manylinux2010_x86_64"
 
 for pyver in ${pyvers[@]}; do

--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -8,11 +8,9 @@
 
 set -e -x
 
-pyvers=(36 37 38)
 platform="manylinux2010_x86_64"
 
-for pyver in ${pyvers[@]}; do
-    pybin="/opt/python/cp${pyver}-cp${pyver}m/bin"
+for pybin in /opt/python/cp3*/bin; do
     $pybin/pip install -r requirements.txt
     $pybin/python setup.py bdist_wheel
 done

--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -10,7 +10,7 @@ set -e -x
 
 platform="manylinux2010_x86_64"
 
-for pybin in /opt/python/cp3*/bin; do
+for pybin in /opt/python/cp3[678]*/bin; do
     $pybin/pip install -r requirements.txt
     $pybin/python setup.py bdist_wheel
 done

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
+pandas
 matplotlib
 sphinx
 sphinx_gallery
 pytest
-cython
+wheel

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     packages=["ndsplines"],
     ext_modules=extensions,


### PR DESCRIPTION
- Add Python 3.8 jobs
- Upgrade macOS images (10.13 was removed)
- Only one Linux job needed -- wheels built in manylinux env
- Always build wheels -- helpful to check wheels before pushing a tag

Fixes #62
