### PR TITLE
Remove package-level impl attr and add a getter

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -48,5 +48,6 @@ evaluation.
     :toctree: api
 
     ~ndsplines.set_impl
+    ~ndsplines.get_impl
     ~ndsplines._bspl
     ~ndsplines._npy_bspl

--- a/ndsplines/__init__.py
+++ b/ndsplines/__init__.py
@@ -2,6 +2,7 @@ from .ndsplines import *
 from .version import __version__
 
 evaluate_spline = None
+_impl = ""
 
 
 def set_impl(name):
@@ -12,7 +13,7 @@ def set_impl(name):
     name : "cython" or "numpy"
         Name of implementation to use.
     """
-    global evaluate_spline
+    global evaluate_spline, _impl
     name = name.lower()
     if name == "cython":
         try:
@@ -20,6 +21,7 @@ def set_impl(name):
 
             ndsplines.impl = _bspl
             evaluate_spline = _bspl.evaluate_spline
+            _impl = "cython"
         except ImportError:
             raise ImportError(
                 "Can't use cython implementation. Install cython then reinstall "
@@ -30,8 +32,14 @@ def set_impl(name):
 
         ndsplines.impl = _npy_bspl
         evaluate_spline = _npy_bspl.evaluate_spline
+        _impl = "numpy"
     else:
         raise ValueError("Implementation must be one of {'cython', 'numpy'}")
+
+
+def get_impl():
+    """Get the current bspl implementation as a string."""
+    return _impl
 
 
 try:
@@ -39,5 +47,7 @@ try:
 except ImportError:
     set_impl("numpy")
 
+
+del impl  # imported here to set it but don't need it in the package namespace
 
 __all__ = [d for d in dir() if not d.startswith("_")]

--- a/tests/test_ndsplines.py
+++ b/tests/test_ndsplines.py
@@ -15,9 +15,11 @@ from utils import get_query_points, assert_equal_splines, _make_random_spline
 def test_evaluate_spline_different_impls():
     """Check that setting the backend implementation is effective."""
     ndsplines.set_impl('numpy')
+    assert ndsplines.get_impl() == 'numpy'
     f_numpy = ndsplines.evaluate_spline
 
     ndsplines.set_impl('cython')
+    assert ndsplines.get_impl() == 'cython'
     f_cython = ndsplines.evaluate_spline
 
     assert f_numpy is not f_cython


### PR DESCRIPTION
On [current master](6949fd71715d0223d04f81851a7d1397ecf4669b), the `ndsplines.impl` attribute is available but is not updated in sync with `ndsplines.ndsplines.impl`:

```python
import ndsplines

ndsplines.set_impl("cython")

print(ndsplines.impl)
print(ndsplines.ndsplines.impl)
```

```
<module 'ndsplines._npy_bspl' from '/home/krlyons/src/ndsplines/ndsplines/_npy_bspl.py'>
<module 'ndsplines._bspl' from '/home/krlyons/src/ndsplines/ndsplines/_bspl.cpython-38-x86_64-linux-gnu.so'>
```

This removes the attribute from the top-level package namespace and adds a `get_impl` method to check what it's set to.