### PR TITLE
Use oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,6 @@ requires = [
     "setuptools>=42",
     "wheel",
     "Cython",
+    "oldest-supported-numpy",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Recently learned about [oldest-supported-numpy](https://github.com/scipy/oldest-supported-numpy), and found we didn't actually have numpy explicitly in the build system requirements.

This should prevent ABI incompatibility issues like I ran across installing the latest ndsplines release in an old-ish conda environment. Probably should go ahead and make a release for this.