### PR TITLE
Build Python 3.12 wheels

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheels and test
-        uses: pypa/cibuildwheel@v2.14.1
+        uses: pypa/cibuildwheel@v2.16.0
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ requires = [
     "setuptools>=45",
     "setuptools_scm[toml]",
     "cython",
-    "oldest-supported-numpy",
+    "oldest-supported-numpy; python_version<'3.12'",
+    "numpy>=1.26.0; python_version>='3.12'",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Python 3.12 wheels for numpy, scipy, and pandas have been released, so we should be able to build them for ndsplines too.