### PR TITLE
Switch to PyPI trusted publishing in dist workflow

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -54,7 +54,12 @@ jobs:
     name: Publish to PyPI
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ndsplines
+    permissions:
+      id-token: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v3
@@ -64,8 +69,3 @@ jobs:
 
       - name: Publish dist to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.11
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          # password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          # repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
- Added an environment on the github side
- Added the workflow/environment on the PyPI side
- Using the current recommended gh-actions-pypi-publish config as of v1.8.11: https://github.com/pypa/gh-action-pypi-publish/tree/2f6f737ca5f74c637829c0f5c3acd0e29ea5e8bf#usage